### PR TITLE
Update Gemfile to use twiddle-wakka operator for ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.0'
-
+ruby "~> 2.3.0"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,5 +166,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.13.6


### PR DESCRIPTION
- This allows the app to stage with any version `2.3.x`
- The latest ruby buildpack versions do not have ruby `2.3.0` anymore. This sample app will not stage with those latest ruby buildpacks: https://concourse.buildpacks-gcp.ci.cf-app.com/teams/main/pipelines/sample-apps/jobs/cf-sample-app-rails-smoke-test/builds/4

[#135427269]